### PR TITLE
Add python bcrypt+hmac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,9 @@ HTTPS it will give a big ugly warning.
 See [`manifesto.md`](https://github.com/seveneightn9ne/hashpass/blob/master/manifesto.md) for
 a full explanation of the algorithm and why it's secure.
 
+## Running the tests.
 
+To run the tests for the python client run:
+```shell
+python tests.py
+```

--- a/alg.py
+++ b/alg.py
@@ -54,21 +54,22 @@ def make_site_password(secret_intermediate, slug, old):
 
 def make_site_password_new(secret_intermediate, slug):
     """
-    1. Concatenate [slug || counter || generation].
+    1. Concatenate (slug, generation, counter) separated by newlines.
     2. Hash (HMAC-Sha256) with secret_intermediate as the key.
     3. Truncate and convert to output character set.
     4. Try again with counter++ if candidate does not satisfy constraints.
     """
     limit = 10000
-    generation = 1 # can be used for future features.
+    generation = 0 # can be used for future features.
     for counter in xrange(limit):
-        combined = "{}{}{}".format(slug, str(generation), str(counter))
+        combined = "\n".join((slug, str(generation), str(counter)))
         hashed_string = _new_hash(secret_intermediate, combined)
         hashed_bytes = map(ord, hashed_string)
         assert len(hashed_bytes) == 32
         candidate = _bytes_to_password_candidate(hashed_bytes[:15])
         if is_good_pass(candidate):
-            return candidate
+            return candidate# TODO(miles): remove these counter lines.
+            return (counter, candidate)# TODO(miles): remove these counter lines.
 
     print "Could not find password after {} tries.".format(limit)
     print "This is improbable or something is wrong."

--- a/hashpass-gui.py
+++ b/hashpass-gui.py
@@ -60,7 +60,7 @@ class HashPass(Tkinter.Frame, object):
     plain = self.entry_var.get()
     if len(plain) == 0 or self.need_master:
       return
-    hashed = make_password(plain)
+    hashed = make_password(plain, old=True)
     self.label_hash.config(text=hashed)
     copy_to_clipboard(hashed)
     self.label_clipboard.config(text=(

--- a/hashpass.py
+++ b/hashpass.py
@@ -64,7 +64,7 @@ def cli(arguments):
     get_password(use_bcrypt)
     if arguments['<website>']:
         w = arguments['<website>']
-        result = make_password(w)
+        result = make_password(w, old=(not use_bcrypt))
         if arguments['--show']:
             print result
         else:
@@ -79,7 +79,7 @@ def cli(arguments):
                 return
             if w == "":
                 return
-            result = make_password(w)
+            result = make_password(w, old=(not use_bcrypt))
             if arguments['--show']:
                 print result
             else:

--- a/hashpasslib.py
+++ b/hashpasslib.py
@@ -43,14 +43,14 @@ def is_correct_master(password):
         return True
     return False
 
-def make_password(slug):
+def make_password(slug, old):
     """
     Turns the password + slug into a 20 character password.
     The password is_good_pass and is deterministic.
     """
     if not session_intermediate:
         raise Exception("Cannot make password without an intermediate pw.")
-    return alg.make_site_password(session_intermediate, slug)
+    return alg.make_site_password(session_intermediate, slug, old=old)
 
 def _mkdir_p(path):
     try:

--- a/tests.py
+++ b/tests.py
@@ -11,6 +11,31 @@ class TestHashPassAlg(unittest.TestCase):
         self.assertEqual(alg.make_intermediate("blowfish"),
           "$2b$13$X5A4.IjQghzyTGwc0wgRrezL8JE8j/mpXN/V6YXoldoca002NMb0a")
 
+    def test_is_good_pass(self):
+        self.assertTrue(alg.is_good_pass("a4#aaaaaaaaaaaaaaaaa"))
+        self.assertTrue(alg.is_good_pass("oooo6o#ooaaaaaaaaaaa"))
+        self.assertFalse(alg.is_good_pass(""))
+        self.assertFalse(alg.is_good_pass("oeuoeuOOO2343"))
+
+    def test_make_storeable(self):
+        secret = "abcdef"
+        stored = alg.make_storeable(secret)
+        self.assertTrue(bcrypt.hashpw(secret, stored) == stored)
+
+    def test_check_stored(self):
+        # Test with an 11 round bcrypt.
+        secret = "blowfish"
+        stored = "$2b$11$Gzhmkebfiz2OapRqu/zWSOH2Wa9uAsbb4Vd5q3iKBILsMRX8MBpQa"
+        self.assertTrue(alg.check_stored(secret, stored))
+        self.assertFalse(alg.check_stored(secret[:-1], stored))
+
+    def test_bytes_to_pw_chars(self):
+        self.assertEqual(alg._bytes_to_pw_chars([0, 0, 0]), "aaaa")
+        self.assertEqual(alg._bytes_to_pw_chars([255, 255, 255]), "????")
+        self.assertEqual(alg._bytes_to_pw_chars([4,32,196]), "bcde")
+
+
+class TestHashPassAlgOld(unittest.TestCase):
     def _test_site(self, rerolls, master, slug, result):
         """Test one site password, ignores the reroll parameter."""
         self.assertEqual(result,
@@ -55,29 +80,6 @@ class TestHashPassAlg(unittest.TestCase):
         self._test_site(5, "iSqlhru8op", "gJiWkK4JcO", "8wTU=am6g{=3BfoL}fuY")
         self._test_site(6, "d9bqrOq7mN", "0ZSK8Ij1RT", "CgK9{jp=8vVgt=8)fJgU")
         self._test_site(7, "S1R1yyV1i0", "ZKyePZecAO", "o}JgLvJv*4cmw{rcAXBo")
-
-    def test_is_good_pass(self):
-        self.assertTrue(alg.is_good_pass("a4#aaaaaaaaaaaaaaaaa"))
-        self.assertTrue(alg.is_good_pass("oooo6o#ooaaaaaaaaaaa"))
-        self.assertFalse(alg.is_good_pass(""))
-        self.assertFalse(alg.is_good_pass("oeuoeuOOO2343"))
-
-    def test_make_storeable(self):
-        secret = "abcdef"
-        stored = alg.make_storeable(secret)
-        self.assertTrue(bcrypt.hashpw(secret, stored) == stored)
-
-    def test_check_stored(self):
-        # Test with an 11 round bcrypt.
-        secret = "blowfish"
-        stored = "$2b$11$Gzhmkebfiz2OapRqu/zWSOH2Wa9uAsbb4Vd5q3iKBILsMRX8MBpQa"
-        self.assertTrue(alg.check_stored(secret, stored))
-        self.assertFalse(alg.check_stored(secret[:-1], stored))
-
-    def test_bytes_to_pw_chars(self):
-        self.assertEqual(alg._bytes_to_pw_chars([0, 0, 0]), "aaaa")
-        self.assertEqual(alg._bytes_to_pw_chars([255, 255, 255]), "????")
-        self.assertEqual(alg._bytes_to_pw_chars([4,32,196]), "bcde")
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -14,24 +14,24 @@ class TestHashPassAlg(unittest.TestCase):
     def _test_site(self, rerolls, master, slug, result):
         """Test one site password, ignores the reroll parameter."""
         self.assertEqual(result,
-                alg.make_site_password(master, slug))
+                alg.make_site_password(master, slug, old=True))
 
     def test_make_site_password(self):
         # reroll 0 times
         self.assertEqual("P4{tRc6X3q}5)bCw}su=",
-                alg.make_site_password("a", "b"))
+                alg.make_site_password("a", "b", old=True))
         self.assertEqual("4D*y7}fP646v3rdWEMz6",
-                alg.make_site_password("batterystapler", "sportsball"))
+                alg.make_site_password("batterystapler", "sportsball", old=True))
 
         # reroll 1 time
         self.assertEqual("C}Kzk*)6(CbR}sM5PxuK",
-                alg.make_site_password("a", "sportsball"))
+                alg.make_site_password("a", "sportsball", old=True))
 
         # bcrypted input
         self.assertEqual("M9PC77h*GmdN@?(hfxcY",
                 alg.make_site_password(
                     "$2b$13$X5A4.IjQghzyTGwc0wgRrecUMeNiIgapq6zxM07dr3UDDdHUYWLTC",
-                    "xyz"))
+                    "xyz", old=True))
 
     def test_make_site_password_more(self):
         self._test_site(0, "wwsx6kolKO", "Ckf2oCe18I", "jzebYcmJ}+8b5rye{9Dn")

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,11 @@ import bcrypt
 import alg
 
 class TestHashPassAlg(unittest.TestCase):
+    def setUp(self):
+        self.intermediates = [
+            "$2b$13$X5A4.IjQghzyTGwc0wgRrebu3hlW/WFyN5GnvrTKvYsJtdsr5DXC6",
+            "$2b$13$X5A4.IjQghzyTGwc0wgRrejiTwszgBLaN3PTew0gRtIrzb5EHsZB2",]
+
     def test_make_intermediate(self):
         self.assertEqual(alg.make_intermediate("1234"),
           "$2b$13$X5A4.IjQghzyTGwc0wgRrecUMeNiIgapq6zxM07dr3UDDdHUYWLTC")
@@ -34,6 +39,34 @@ class TestHashPassAlg(unittest.TestCase):
         self.assertEqual(alg._bytes_to_pw_chars([255, 255, 255]), "????")
         self.assertEqual(alg._bytes_to_pw_chars([4,32,196]), "bcde")
 
+    def _test_site(self, rerolls, master, slug, result):
+        """Test one site password, ignores the reroll parameter."""
+        self.assertEqual(result,
+                alg.make_site_password(master, slug, old=False))
+
+    def test_make_site_password(self):
+        # reroll 0 times
+        self.assertEqual("?T7}LNgNP)KkEYRATQ6m",
+                alg.make_site_password(self.intermediates[0], "b", old=False))
+        self.assertEqual("DuR49nd4W7@fEyH)M?Xk",
+                alg.make_site_password(self.intermediates[1], "b", old=False))
+
+        # reroll 1 time
+        self.assertEqual("frP}JsfQXxjp5FTt}y{k",
+                alg.make_site_password(self.intermediates[0], "blunderbus40", old=False))
+        self.assertEqual("NquDtLpKUhSRS7TgBY}f",
+                alg.make_site_password(self.intermediates[1], "sportsball", old=False))
+
+
+    def test_make_site_password_more(self):
+        self._test_site(3, self.intermediates[0],
+                        "blunderbus67555", "q7=s(}5nFgQEr8}JXoxv")
+        self._test_site(4, self.intermediates[0],
+                        "blunderbus67679", "3dfdqnu@YfBGx)}*ByQ3")
+        self._test_site(6, self.intermediates[0],
+                        "blunderbus403936", "V5Wuv?4kG*(?X)bpw?}V")
+        self._test_site(6, self.intermediates[0],
+                        "blunderbus463867", "TDpxs?Fs#5SQ5*rCX#=z")
 
 class TestHashPassAlgOld(unittest.TestCase):
     def _test_site(self, rerolls, master, slug, result):


### PR DESCRIPTION
This finishes up support for bcrypt and adds hmac-based final key derivation.
You can run with `-b` and it works.
Bcrypt is still not the default.
The gui is hardcoded to the old default.
Still no web support.
